### PR TITLE
TC-4809 (fix "simple events")

### DIFF
--- a/walkthrough/events.rst
+++ b/walkthrough/events.rst
@@ -52,13 +52,21 @@
          
     - ``venue`` место проведения
       
-       - ``id`` **str**::ref:`objectid <extra/types/objectid>` - venue id
+       - ``id`` **str**::ref:`objectid <extra/types/objectid>`
        - ``address`` **str** - адрес
        - ``country`` страна
+          - ``id`` **str** - буквенное короткое латинское название
+          - ``name`` - ассоциативный массив названий на разных языках
        - ``city`` город
+          - ``id`` **int**
+          - ``country`` **str** - id страны
+          - ``name`` - ассоциативный массив названий на разных языках
+          - ``timezone`` **str** - временная зона
        - ``name`` **str** - название
        - ``desc`` **str** - краткое описание
        - ``point`` координата (`GeoJSON <http://geojson.org>`_'s point)
+          - ``coordinates`` **list** список двух вещественных координат
+          - ``type`` **str** - тип
 
     - ``map`` схема зала
 
@@ -76,14 +84,13 @@
        - ``seats`` **object** - row: numbers (**list**)
        - ``sector`` сектор
 
-    - ``rules`` правила
-
-       - ``id``
-       - ``cal`` :ref:`vevent <extra/types/vevent>`, время действия правила
-       - ``current`` **bool** - `true` если правило текущее
-       - ``price_org`` **str**:*Money* - номинальная цена
-       - ``price_extra`` - сервисный сбор
-       - ``price`` **str**:*Money* - конечная цена
+       - ``rules`` список правил
+          - ``id``
+          - ``cal`` :ref:`vevent <extra/types/vevent>`, время действия правила
+          - ``current`` **bool** - `true` если правило текущее
+          - ``price_org`` **str**:*Money* - номинальная цена
+          - ``price_extra`` - сервисный сбор
+          - ``price`` **str**:*Money* - конечная цена
 
 
 **Пример запроса**:


### PR DESCRIPTION
https://ticketscloud.atlassian.net/browse/TC-4809

>В пример по запросу мероприятий необходимо добавить сеты с правилами повышения продаж. Сейчас пусто — http://joxi.ru/xAe1984fR5ZLaA

Уже сделано, дока просто не собралась

> В описании сетов правила должны быть вложены в сеты, сейчас на одном уровне — http://joxi.ru/D2PDO6wSq6Yva2

Добавил

>В описании площадки не развернута структура города, не описана таймзона в том числе и вообще не соответствует примеру. Документация — http://joxi.ru/8An6P3KuzWn06A Пример — http://joxi.ru/L21013kfRaLVYm

Добавил