### PR TITLE
[TC-4013] Fix parameters description for POST and PATCH requests.

### DIFF
--- a/extra/orders.rst
+++ b/extra/orders.rst
@@ -27,7 +27,7 @@
 
     .. http:post:: /v2/resources/orders/:id
 
-        :jsonparam settings: Словарь с одним ключом customer, содержащим:
+        :jsonparam settings: объект с одним ключом customer и соответствующим ему значением, содержащим:
 
             - **name** (str)
             - **email** (str)

--- a/extra/orders.rst
+++ b/extra/orders.rst
@@ -27,7 +27,7 @@
 
     .. http:post:: /v2/resources/orders/:id
 
-        :query settings:
+        :jsonparam settings: Словарь с одним ключом customer, содержащим:
 
             - **name** (str)
             - **email** (str)
@@ -117,7 +117,7 @@
 
     .. http:post:: /v2/resources/orders/:id
 
-        :query vendor_data:
+        :jsonparam vendor_data:
 
             - **order_id**  (str) (Необязательно) Номер заказа в системе распространителя. Максимальная длина 64 символа
             - **raw** (object) Объект с произвольными полями.
@@ -212,7 +212,7 @@
 
     .. http:post:: /v2/resources/orders/:id
 
-        :query settings:
+        :jsonparam settings:
 
             - **send_tickets** (bool)
 
@@ -304,7 +304,7 @@
 
     .. http:patch:: /v2/resources/orders/:id
 
-        :query promocodes: (list of string)
+        :jsonparam promocodes: (list of string)
 
 **Ответ**
 

--- a/extra/promocodes.rst
+++ b/extra/promocodes.rst
@@ -20,7 +20,7 @@ c кодом ответа 400. В остальных случаях возвра
 
     .. http:post:: /v2/services/promocodes/check
 
-            :jsonparam event: Id заказа (str)
+            :jsonparam event: id мероприятия (str)
             :jsonparam code: код (str)
 
 

--- a/extra/promocodes.rst
+++ b/extra/promocodes.rst
@@ -20,8 +20,8 @@ c кодом ответа 400. В остальных случаях возвра
 
     .. http:post:: /v2/services/promocodes/check
 
-            - **event** (str)
-            - **code** (str)
+            :jsonparam event: Id заказа (str)
+            :jsonparam code: код (str)
 
 
 **Ответ**

--- a/walkthrough/order_create.rst
+++ b/walkthrough/order_create.rst
@@ -352,7 +352,7 @@
 
     .. http:patch:: /v2/resources/orders/:id
 
-        :query tickets: список id билетов
+        :jsonparam tickets: список id билетов
 
 **Пример запроса**
 
@@ -391,7 +391,7 @@
 
     .. http:patch:: /v2/resources/orders/:id
 
-        :query random: массив: ключ -- id категории, значение -- кол-во мест
+        :jsonparam random: массив: ключ -- id категории, значение -- кол-во мест
 
 **Пример запроса**
 

--- a/walkthrough/refund_requests.rst
+++ b/walkthrough/refund_requests.rst
@@ -14,10 +14,10 @@
 
     .. http:post:: /v2/resources/refund_requests/
 
-       :query order: Id заказа
-       :query culprit: Виновник возврата (``user`` | ``org``)
-       :query tickets: Список id билетов для возврата
-       :query requested_at: Дата и время заявки на возврат. Необязательный параметр.
+       :jsonparam order: Id заказа
+       :jsonparam culprit: Виновник возврата (``user`` | ``org``)
+       :jsonparam tickets: Список id билетов для возврата
+       :jsonparam requested_at: Дата и время заявки на возврат. Необязательный параметр.
 
 
 **Ответ**
@@ -207,7 +207,7 @@
 
     .. http:patch:: /v2/resources/refund_requests/:refund_id
 
-       :query status: ``approved`` | ``rejected``
+       :jsonparam status: ``approved`` | ``rejected``
 
 **Ответ**
 


### PR DESCRIPTION
Параметры POST и PATCH, передаваемые в формате JSON в теле запроса, помечены как jsonparam вместо query.
Попутно исправлена ошибка в описании формата запроса на /v2/resources/orders/:id